### PR TITLE
fix(lib): Make block-write-stream chunk inputs

### DIFF
--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -16,3 +16,9 @@ export function difference<T>(setA: Set<T>, setB: Set<T>): Set<T> {
 	}
 	return _difference;
 }
+
+export function asCallback(promise: Promise<any>, callback: (error: Error | void, value?: any) => void) {
+	promise.then((value: any) => {
+		callback(undefined, value);
+	}).catch(callback)
+}


### PR DESCRIPTION
This backports Etcher's `block-stream` behavior into `BlockWriteStream`

Connects to: #3 
Change-Type: minor
Signed-off-by: Jonas Hermsmeier <jhermsmeier@gmail.com>