### PR TITLE
Use the BlockDevice or File in read and write streams, not the fd

### DIFF
--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -15,3 +15,4 @@
  */
 
 export const PROGRESS_EMISSION_INTERVAL = 1000 / 2;  // emit progress events 2 times per second
+export const RETRY_BASE_TIMEOUT = 100;

--- a/lib/destination-sparse-write-stream.ts
+++ b/lib/destination-sparse-write-stream.ts
@@ -1,0 +1,93 @@
+import { Chunk } from 'blockmap';
+import { delay } from 'bluebird';
+import { Writable } from 'readable-stream';
+
+import { makeClassEmitProgressEvents } from './source-destination/progress';
+import { SourceDestination } from './source-destination/source-destination';
+
+import { PROGRESS_EMISSION_INTERVAL, RETRY_BASE_TIMEOUT } from './constants';
+import { isTransientError } from './errors';
+import { SparseWriteStream } from './sparse-write-stream';
+import { asCallback } from './utils';
+
+export class DestinationSparseWriteStream extends Writable implements SparseWriteStream {
+	public position: number;
+	public bytesWritten = 0;
+	private _firstChunks: Chunk[] = [];
+
+	constructor(private destination: SourceDestination, public firstBytesToKeep = 0, private maxRetries = 5) {
+		super({ objectMode: true });
+	}
+
+	private async writeChunk(chunk: Chunk, flushing = false): Promise<void> {
+		let retries = 0;
+		while (true) {
+			try {
+				this.position = chunk.position;
+				await this.destination.write(chunk.buffer, 0, chunk.length, chunk.position);
+				if (!flushing) {
+					this.position += chunk.length;
+					this.bytesWritten += chunk.length;
+				}
+				return;
+			} catch (error) {
+				if (isTransientError(error)) {
+					if (retries < this.maxRetries) {
+						retries += 1;
+						await delay(RETRY_BASE_TIMEOUT * retries);
+						continue;
+					}
+					error.code = 'EUNPLUGGED';
+				}
+				throw error;
+			}
+		}
+	}
+
+	private async __write(chunk: Chunk): Promise<void> {
+		// Keep the first blocks in memory and write them once the rest has been written.
+		// This is to prevent Windows from mounting the device while we flash it.
+		if (chunk.position < this.firstBytesToKeep) {
+			const end = chunk.position + chunk.length;
+			if (end <= this.firstBytesToKeep) {
+				this._firstChunks.push(chunk);
+				this.position = chunk.position + chunk.length;
+				this.bytesWritten += chunk.length;
+			} else {
+				const difference = this.firstBytesToKeep - chunk.position;
+				this._firstChunks.push({ position: chunk.position, buffer: chunk.buffer.slice(0, difference), length: difference });
+				this.position = this.firstBytesToKeep;
+				this.bytesWritten += difference;
+				const remainingBuffer = chunk.buffer.slice(difference);
+				await this.writeChunk({ position: this.firstBytesToKeep, buffer: remainingBuffer, length: remainingBuffer.length });
+			}
+		} else {
+			await this.writeChunk(chunk);
+		}
+	}
+
+	_write(chunk: Chunk, enc: string, callback: (error?: Error | void) => void): void {
+		asCallback(this.__write(chunk), callback);
+	}
+
+	async __final(): Promise<void> {
+		try {
+			for (const chunk of this._firstChunks) {
+				await this.writeChunk(chunk, true);
+			}
+		} catch (error) {
+			this.destroy();
+			throw error;
+		}
+	}
+
+	/**
+	 * @summary Write buffered data before a stream ends, called by stream internals
+	 */
+	_final(callback: (error?: Error | void) => void) {
+		asCallback(this.__final(), callback);
+	}
+}
+
+export const ProgressDestinationSparseWriteStream = makeClassEmitProgressEvents(DestinationSparseWriteStream, 'bytesWritten', 'position', PROGRESS_EMISSION_INTERVAL);
+

--- a/lib/multi-write.ts
+++ b/lib/multi-write.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { createHasher, ProgressHashStream, SourceDestination, Verifier } from './source-destination/source-destination';
+import { createHasher, CountingHashStream, ProgressHashStream, SourceDestination, Verifier } from './source-destination/source-destination';
 import { Metadata } from './source-destination/metadata';
 import { MultiDestination, MultiDestinationError } from './source-destination/multi-destination';
 import { ProgressEvent } from './source-destination/progress';
@@ -177,9 +177,7 @@ async function pipeRegularSourceToDestination(
 	const checksum = await new Promise((resolve: (checksum: string | undefined) => void, reject: (error: Error) => void) => {
 		let checksum: string;
 		let done = false;
-		// Not sure why typescript can't find ProgressHashStream here
-		// @ts-ignore
-		let hasher: ProgressHashStream;
+		let hasher: CountingHashStream;
 		function maybeDone(maybeChecksum?: string) {
 			if (maybeChecksum !== undefined) {
 				checksum = maybeChecksum;

--- a/lib/scanner/adapters/usbboot.ts
+++ b/lib/scanner/adapters/usbboot.ts
@@ -23,6 +23,7 @@ import { Adapter } from './adapter';
 
 let UsbbootScanner: typeof UsbbootScannerType | undefined = undefined;
 try {
+	// tslint:disable: no-var-requires
 	UsbbootScanner = require('node-raspberrypi-usbboot').UsbbootScanner;
 } catch (error) {
 	console.warn('Failed to import node-raspberrypi-usbboot:', error);

--- a/lib/source-destination/index.ts
+++ b/lib/source-destination/index.ts
@@ -28,5 +28,6 @@ export * from './multi-destination';
 export * from './progress';
 export * from './resin-s3-source';
 export * from './source-destination';
+export * from './source-source';
 export * from './usbboot';
 export * from './zip';

--- a/lib/source-destination/zip.ts
+++ b/lib/source-destination/zip.ts
@@ -118,6 +118,7 @@ export class RandomAccessZipSource extends SourceSource {
 	}
 
 	async init() {
+		await this.source.open();
 		const sourceMetadata = await this.source.getMetadata();
 		const reader = new SourceRandomAccessReader(this.source);
 		this.zip = await fromCallback((callback: (err: any, result?: ZipFile) => void) => {
@@ -215,7 +216,7 @@ export class RandomAccessZipSource extends SourceSource {
 			throw new NotCapable();
 		}
 		if (end !== undefined) {
-			// TODO: handle errors on stream after transform finsh event
+			// TODO: handle errors on stream after transform finish event
 			const transform = new StreamLimiter(stream, end + 1);
 			return transform;
 		}

--- a/tests/block-write-stream.spec.ts
+++ b/tests/block-write-stream.spec.ts
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2018 resin.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import 'mocha';
+import { using } from 'bluebird';
+import { expect } from 'chai';
+import { randomBytes as randomBytesNode } from 'crypto';
+import * as os from 'os';
+import { join } from 'path';
+import { spy, stub } from 'sinon';
+import { Readable } from 'stream';
+
+import { BlockWriteStream } from '../lib/block-write-stream';
+import { DestinationSparseWriteStream } from '../lib/destination-sparse-write-stream';
+import { BlockDevice } from '../lib/source-destination/block-device';
+import * as diskpart from '../lib/diskpart';
+import { readFile } from '../lib/fs';
+import { tmpFileDisposer, TmpFileResult } from '../lib/tmp';
+import { blockDeviceFromFile, DEFAULT_IMAGE_TESTS_TIMEOUT } from './tester';
+
+async function randomBytes(size: number): Promise<Buffer> {
+	return await new Promise((resolve: (stats: Buffer) => void, reject: (err: Error) => void) => {
+		randomBytesNode(size, (err: Error, buffer: Buffer) => {
+			if (err) {
+				reject(err);
+				return;
+			}
+			resolve(buffer);
+		});
+	});
+}
+
+function* bufferChunks(buffer: Buffer, chunkSize: number) {
+	for (let position = 0; position < buffer.length; position += chunkSize) {
+		const slice = buffer.slice(position, position + chunkSize);
+		yield { position, buffer: slice, length: slice.length };
+	}
+}
+
+function bufferToStream(stream: Readable, buffer: Buffer, chunkSize: number): void {
+	for (const chunk of bufferChunks(buffer, chunkSize)) {
+		stream.push(chunk.buffer);
+	}
+	stream.push(null);
+}
+
+function bufferToSparseStream(stream: Readable, buffer: Buffer, chunkSize: number): void {
+	for (const chunk of bufferChunks(buffer, chunkSize)) {
+		stream.push(chunk);
+	}
+	stream.push(null);
+}
+
+async function expectFileToContain(path: string, data: Buffer): Promise<void> {
+	const fileData = await readFile(path);
+	expect(fileData.slice(0, data.length)).to.deep.equal(data);
+}
+
+describe('block-write-stream', function() {
+	this.timeout(DEFAULT_IMAGE_TESTS_TIMEOUT);
+	const SIZE = 64 * 1024 + 7;
+	const CHUNK_SIZE = 512;
+
+	async function testBlockWriteStream(size: number, chunkSize: number, sparse = false): Promise<void> {
+		const data = await randomBytes(size);
+		const input = new Readable({ objectMode: sparse });
+		await using(tmpFileDisposer(false), async (file: TmpFileResult) => {
+			const destination = await blockDeviceFromFile(file.path);
+			await destination.open();
+			let output: BlockWriteStream | DestinationSparseWriteStream;
+			if (sparse) {
+				output = await destination.createSparseWriteStream();
+			} else {
+				output = await destination.createWriteStream();
+			}
+			spy(destination, 'write');
+			await new Promise((resolve, reject) => {
+				output.on('finish', resolve);
+				output.on('error', reject);
+				input.pipe(output);
+				if (sparse) {
+					bufferToSparseStream(input, data, chunkSize);
+				} else {
+					bufferToStream(input, data, chunkSize);
+				}
+			});
+			// Check that the first bytes are written last on windows.
+			// ts-ignores are for accessing getCall() which is added by the spy() above.
+			if (os.platform() === 'win32') {
+				expect(output.firstBytesToKeep).to.not.equal(0);
+				// @ts-ignore
+				expect(destination.write.getCall(0).args[3]).to.equal(output.firstBytesToKeep);
+				// @ts-ignore
+				expect(destination.write.getCall(1).args[3]).to.equal(0);
+			} else {
+				// @ts-ignore
+				expect(destination.write.getCall(0).args[3]).to.equal(0);
+				// @ts-ignore
+				expect(destination.write.getCall(1).args[3]).to.equal(chunkSize);
+			}
+			expect(output.bytesWritten).to.equal(size);
+			await destination.close();
+			await expectFileToContain(file.path, data);
+		});
+	}
+
+	describe('win32', function() {
+		before(function() {
+			this.osPlatformStub = stub(os, 'platform');
+			this.osPlatformStub.returns('win32');
+			this.diskpartCleanStub = stub(diskpart, 'clean');
+		});
+
+		after(function() {
+			this.osPlatformStub.restore();
+			this.diskpartCleanStub.restore();
+		});
+
+		it('should write the correct bytes', testBlockWriteStream.bind(null, SIZE, CHUNK_SIZE));
+		it('should write the correct bytes sparse', testBlockWriteStream.bind(null, SIZE, CHUNK_SIZE, true));
+	});
+
+	describe('linux', function() {
+		before(function() {
+			this.osPlatformStub = stub(os, 'platform');
+			this.osPlatformStub.returns('linux');
+		});
+
+		after(function() {
+			this.osPlatformStub.restore();
+		});
+
+		it('should write the correct bytes', testBlockWriteStream.bind(null, SIZE, CHUNK_SIZE));
+		it('should write the correct bytes sparse', testBlockWriteStream.bind(null, SIZE, CHUNK_SIZE, true));
+	});
+
+});

--- a/tests/dmg.spec.ts
+++ b/tests/dmg.spec.ts
@@ -47,6 +47,8 @@ describe('dmg support', function() {
 			true,   // shouldHaveCompressedSize
 			'mbr',  // partitionTableType
 			join(IMAGES_PATH, 'etcher-test-partitions.json'),  // partitionsFile
+			{},  // expectedMetadata
+			sourceDestination.DmgSource,
 		);
 	});
 

--- a/tests/img.spec.ts
+++ b/tests/img.spec.ts
@@ -21,6 +21,7 @@ import { createGunzip } from 'zlib';
 
 import { DEFAULT_IMAGE_TESTS_TIMEOUT, testImage, testImageNoIt  } from './tester';
 
+import { sourceDestination } from '../lib';
 import { unlink } from '../lib/fs';
 import { tmpFile } from '../lib/tmp';
 
@@ -53,7 +54,7 @@ describe('img', function() {
 		'mbr',
 		join(IMAGES_PATH, 'etcher-test.img'),
 		join(IMAGES_PATH, 'etcher-test.img'),
-		true,  // alsoTestSparseStream
+		false,  // alsoTestSparseStream
 		true,  // shouldHaveSize
 		false,   // shouldHaveCompressedSize
 		'mbr',  // partitionTableType
@@ -65,9 +66,10 @@ describe('img', function() {
 			join(IMAGES_PATH, 'etcher-gpt-test.img.gz'),
 			// @ts-ignore
 			gunzippedFilePath,
-			true,  // alsoTestSparseStream
+			false,  // alsoTestSparseStream
 			true,  // shouldHaveSize
 			false,   // shouldHaveCompressedSize
+			sourceDestination.File,  // sourceClass (File or BlockDevice)
 			'gpt',  // partitionTableType
 			join(IMAGES_PATH, 'etcher-gpt-test-partitions.json'),  // partitionsFile
 		);

--- a/tests/iso.spec.ts
+++ b/tests/iso.spec.ts
@@ -29,7 +29,7 @@ describe('iso support', function() {
 		'iso',
 		join(IMAGES_PATH, 'etcher-test.iso'),
 		join(IMAGES_PATH, 'etcher-test.iso'),
-		true,  // alsoTestSparseStream
+		false,  // alsoTestSparseStream
 		true,  // shouldHaveSize
 		false,   // shouldHaveCompressedSize
 		'mbr',  // partitionTableType

--- a/tests/metadata-zip.spec.ts
+++ b/tests/metadata-zip.spec.ts
@@ -41,7 +41,7 @@ describe('metadata zip', function() {
 		'given an archive with a `manifest.json`',
 		join(ZIP_PATH, 'etcher-test-with-manifest.zip'),
 		join(IMAGES_PATH, 'etcher-test.img'),
-		true,  // alsoTestSparseStream
+		false,  // alsoTestSparseStream
 		true,  // shouldHaveSize
 		7791,   // shouldHaveCompressedSize
 		'mbr',  // partitionTableType
@@ -63,7 +63,7 @@ describe('metadata zip', function() {
 		'given an archive with a `logo.svg`',
 		join(ZIP_PATH, 'etcher-test-with-logo.zip'),
 		join(IMAGES_PATH, 'etcher-test.img'),
-		true,  // alsoTestSparseStream
+		false,  // alsoTestSparseStream
 		true,  // shouldHaveSize
 		7791,   // shouldHaveCompressedSize
 		'mbr',  // partitionTableType
@@ -110,7 +110,7 @@ describe('metadata zip', function() {
 		'given an archive with instructions',
 		join(ZIP_PATH, 'etcher-test-with-instructions.zip'),
 		join(IMAGES_PATH, 'etcher-test.img'),
-		true,  // alsoTestSparseStream
+		false,  // alsoTestSparseStream
 		true,  // shouldHaveSize
 		7791,   // shouldHaveCompressedSize
 		'mbr',  // partitionTableType

--- a/typings/drivelist/index.d.ts
+++ b/typings/drivelist/index.d.ts
@@ -12,6 +12,7 @@ declare module 'drivelist' {
 		raw: string;
 		devicePath: string;
 		isReadOnly: boolean;
+		blockSize?: number;
 	}
 
 	export function list(callback: (error: Error, drives: Drive[]) => void): void;


### PR DESCRIPTION
 * The first bytes of a stream are only written to the disk last on
Windows;
 * on Windows, writes and reads to block devices are aligned on the device
block size. Unaligned writes will read first, update the buffer then
write;
 * files return regular streams;
 * tests for write streams and sparse write streams.

Connects-to: #19
Connects-to: #21
Change-type: minor
Signed-off-by: Alexis Svinartchouk <alexis@resin.io>