### PR TITLE
fix(progress): Fallback to source progress on gzip streams

### DIFF
--- a/.resinci.yml
+++ b/.resinci.yml
@@ -1,8 +1,10 @@
 ---
 npm:
-  versions:
+  platforms:
     - platform: linux
       os: ubuntu
+      packages:
+        - "libudev-dev"
       architecture: x86_64
       node_versions:
         - "6"
@@ -10,6 +12,8 @@ npm:
         - "10"
     - platform: linux
       os: ubuntu
+      packages:
+        - "libudev-dev"
       architecture: x86
       node_versions:
         - "6"

--- a/lib/multi-write.ts
+++ b/lib/multi-write.ts
@@ -55,6 +55,10 @@ export interface PipeSourceToDestinationsResult {
 	bytesWritten: number;
 }
 
+function getEta(current: number, total: number, speed: number): number | undefined {
+	return (speed === 0) ? undefined : (total - current) / speed;
+}
+
 // This function is the most common use case of the SDK.
 // Added it here to avoid duplicating it in other projects.
 export async function pipeSourceToDestinations(
@@ -133,12 +137,12 @@ export async function pipeSourceToDestinations(
 			size = state.size;
 			bytesWritten = progress.position;
 		}
-		if ((size !== undefined) && (bytesWritten !== undefined)) {
+		if ((size !== undefined) && (bytesWritten !== undefined) && (bytesWritten <= size)) {
 			percentage = bytesWritten / size * 100;
-			eta = (size - bytesWritten) / progress.speed;
+			eta = getEta(bytesWritten, size, progress.speed);
 		} else if ((state.rootStreamSpeed !== undefined) && (state.rootStreamPosition !== undefined) && (state.compressedSize !== undefined)) {
 			percentage = state.rootStreamPosition / state.compressedSize * 100;
-			eta = (state.compressedSize - state.rootStreamPosition) / state.rootStreamSpeed;
+			eta = getEta(state.rootStreamPosition, state.compressedSize, state.rootStreamSpeed);
 		}
 		const result: MultiDestinationProgress = Object.assign(
 			{},


### PR DESCRIPTION
If the number of bytes written exceeds the image size reported in
metadata, we fall back to reporting the progress based on the bytes read
from the compressed file.
This fixes the progress being > 100% for gzipped images over 4GiB.

Connects-to: #25
Change-type: patch
Signed-off-by: Alexis Svinartchouk <alexis@resin.io>