### PR TITLE
fix(block-device): Don't unmount the drive before flashing on win32

### DIFF
--- a/lib/source-destination/block-device.ts
+++ b/lib/source-destination/block-device.ts
@@ -110,7 +110,9 @@ export class BlockDevice extends File implements AdapterSourceDestination {
 	}
 
 	protected async _open(): Promise<void> {
-		await unmountDiskAsync(this.drive.device);
+		if (platform() !== 'win32') {
+			await unmountDiskAsync(this.drive.device);
+		}
 		await clean(this.drive.device);
 		await super._open();
 	}


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Alexis Svinartchouk <alexis@resin.io>