### PR TITLE
fix(file): Use BlockReadStream for File instances

### DIFF
--- a/lib/block-read-stream.ts
+++ b/lib/block-read-stream.ts
@@ -21,7 +21,7 @@ import { Readable } from 'readable-stream';
 
 import { PROGRESS_EMISSION_INTERVAL, RETRY_BASE_TIMEOUT } from './constants';
 import { isTransientError } from './errors';
-import { BlockDevice } from './source-destination/block-device';
+import { File } from './source-destination/file';
 import { makeClassEmitProgressEvents } from './source-destination/progress';
 
 const DEFAULT_CHUNK_SIZE = 64 * 1024;
@@ -29,7 +29,7 @@ const DEFAULT_CHUNK_SIZE = 64 * 1024;
 export class BlockReadStream extends Readable {
 	private chunkSize: number;
 
-	constructor(private source: BlockDevice, private bytesRead = 0, private end = Infinity, chunkSize = DEFAULT_CHUNK_SIZE, private maxRetries = 5) {
+	constructor(private source: File, private bytesRead = 0, private end = Infinity, chunkSize = DEFAULT_CHUNK_SIZE, private maxRetries = 5) {
 		super({ objectMode: true, highWaterMark: 2 });
 		this.chunkSize = Math.max(Math.floor(chunkSize / this.source.blockSize) * this.source.blockSize, this.source.blockSize);
 	}

--- a/lib/source-destination/block-device.ts
+++ b/lib/source-destination/block-device.ts
@@ -21,7 +21,6 @@ import { unmountDisk } from 'mountutils';
 import { platform } from 'os';
 
 import { AdapterSourceDestination } from '../scanner/adapters/adapter';
-import { BlockReadStream, ProgressBlockReadStream } from '../block-read-stream';
 import { BlockWriteStream, ProgressBlockWriteStream } from '../block-write-stream';
 import { DestinationSparseWriteStream, ProgressDestinationSparseWriteStream } from '../destination-sparse-write-stream';
 import { clean } from '../diskpart';
@@ -39,7 +38,6 @@ const WIN32_FIRST_BYTES_TO_KEEP = 64 * 1024;
 const unmountDiskAsync = promisify(unmountDisk);
 
 export class BlockDevice extends File implements AdapterSourceDestination {
-	public blockSize: number;
 	emitsProgress = false;
 
 	constructor(private drive: DrivelistDrive, private unmountOnSuccess = false) {
@@ -91,10 +89,6 @@ export class BlockDevice extends File implements AdapterSourceDestination {
 
 	async canCreateSparseWriteStream(): Promise<boolean> {
 		return !this.drive.isReadOnly;
-	}
-
-	async _createReadStream(start = 0, end?: number): Promise<BlockReadStream> {
-		return new ProgressBlockReadStream(this, start, end, 1024 * this.blockSize);  // TODO: constant
 	}
 
 	async createWriteStream(): Promise<BlockWriteStream> {

--- a/lib/source-destination/file.ts
+++ b/lib/source-destination/file.ts
@@ -28,15 +28,15 @@ import { SourceDestination } from './source-destination';
 import { PROGRESS_EMISSION_INTERVAL } from '../constants';
 import { close, stat, open, read, write } from '../fs';
 import { DestinationSparseWriteStream, ProgressDestinationSparseWriteStream } from '../destination-sparse-write-stream';
+import { ProgressBlockReadStream } from '../block-read-stream';
 
-// type definitions for node 6 export fs.ReadStream and fs.Write stream as interfaces, but they are classes.
-// @ts-ignore
-export const ProgressReadStream = makeClassEmitProgressEvents(fs.ReadStream, 'bytesRead', 'bytesRead', PROGRESS_EMISSION_INTERVAL);
+// type definitions for node 6 export fs.WriteStream as an interface, but it's a class.
 // @ts-ignore
 export const ProgressWriteStream = makeClassEmitProgressEvents(fs.WriteStream, 'bytesWritten', 'bytesWritten', PROGRESS_EMISSION_INTERVAL);
 
 export class File extends SourceDestination {
 	protected fd: number;
+	public blockSize = 512;
 
 	constructor(private path: string, private flags: File.OpenFlags) {
 		super();
@@ -93,7 +93,7 @@ export class File extends SourceDestination {
 	}
 
 	async _createReadStream(start = 0, end?: number): Promise<NodeJS.ReadableStream> {
-		return new ProgressReadStream(null, { fd: this.fd, start, end, autoClose: false, highWaterMark: 1024 * 1024 });  // TODO: constant
+		return new ProgressBlockReadStream(this, start, end);
 	}
 
 	async createWriteStream(): Promise<NodeJS.WritableStream> {


### PR DESCRIPTION
Using a regular fs.ReadStream yields different chunk sizes and slows
down the write stream.

Change-type: patch
Signed-off-by: Alexis Svinartchouk <alexis@resin.io>