### PR TITLE
fix(block-write-stream): Fix block-write-stream tests

### DIFF
--- a/lib/block-write-stream.ts
+++ b/lib/block-write-stream.ts
@@ -25,7 +25,8 @@ import { makeClassEmitProgressEvents } from './source-destination/progress';
 import { BlockDevice } from './source-destination/block-device';
 
 const debug = _debug('etcher:writer:block-write-stream');
-const CHUNK_SIZE = 1024 ** 2;
+
+export const CHUNK_SIZE = 1024 ** 2;
 
 export class BlockWriteStream extends Writable {
 	public bytesWritten = 0;


### PR DESCRIPTION
Tests were broken by f3b2e8c512521a357406d0163928323bfe31ed74

Change-type: patch
Signed-off-by: Alexis Svinartchouk <alexis@resin.io>