### PR TITLE
fix(block-device): Fix BlockDevice.alignedRead() bytesRead property

### DIFF
--- a/lib/source-destination/block-device.ts
+++ b/lib/source-destination/block-device.ts
@@ -157,10 +157,15 @@ export class BlockDevice extends File implements AdapterSourceDestination {
 		const start = this.alignOffsetBefore(sourceOffset);
 		const end = this.alignOffsetAfter(sourceOffset + length);
 		const alignedBuffer = Buffer.allocUnsafe(end - start);
-		await super.read(alignedBuffer, 0, alignedBuffer.length, start);
+		const { bytesRead } = await super.read(
+			alignedBuffer,
+			0,
+			alignedBuffer.length,
+			start,
+		);
 		const offset = sourceOffset - start;
 		alignedBuffer.copy(buffer, bufferOffset, offset, offset + length);
-		return { buffer, bytesRead: length };
+		return { buffer, bytesRead: Math.min(length, bytesRead - offset) };
 	}
 
 	async read(


### PR DESCRIPTION
Never return a bytesRead that is larger than the bytes we've actually
read.

Change-type: patch
Signed-off-by: Alexis Svinartchouk <alexis@resin.io>